### PR TITLE
Forgiving parsing

### DIFF
--- a/Sources/DNS/Bytes.swift
+++ b/Sources/DNS/Bytes.swift
@@ -128,13 +128,13 @@ extension Message {
         var bytes = Data()
         var labels = Labels()
         let qr: UInt16 = type == .response ? 1 : 0
-        let flags: UInt16 = qr << 15
-            | UInt16(operationCode.rawValue) << 11
-            | (authoritativeAnswer ? 1 : 0) << 10
-            | (truncation ? 1 : 0) << 9
-            | (recursionDesired ? 1 : 0) << 8
-            | (recursionAvailable ? 1 : 0) << 7
-            | UInt16(returnCode.rawValue)
+        var flags: UInt16 = qr << 15
+        flags |= UInt16(operationCode.rawValue) << 11
+        flags |= (authoritativeAnswer ? 1 : 0) << 10
+        flags |= (truncation ? 1 : 0) << 9
+        flags |= (recursionDesired ? 1 : 0) << 8
+        flags |= (recursionAvailable ? 1 : 0) << 7
+        flags |= UInt16(returnCode.rawValue)
 
         // header
         bytes += id.bytes

--- a/Sources/DNS/Bytes.swift
+++ b/Sources/DNS/Bytes.swift
@@ -28,8 +28,9 @@ func unpackName(_ data: Data, _ position: inout Data.Index) throws -> String {
             guard var pointer = data.index(data.startIndex, offsetBy: offset, limitedBy: data.endIndex) else {
                 throw DecodeError.invalidLabelOffset
             }
-            // Prevent cyclic references. I think it's safe to assume that label
-            // pointers only point to a prior label.
+            // Prevent cyclic references
+            // Its safe to assume the pointer is to an earlier label
+            // See https://www.ietf.org/rfc/rfc1035.txt 4.1.4
             guard pointer < startPosition else {
                 throw DecodeError.invalidLabelOffset
             }

--- a/Sources/DNS/Bytes.swift
+++ b/Sources/DNS/Bytes.swift
@@ -6,7 +6,6 @@ enum EncodeError: Swift.Error {
 
 enum DecodeError: Swift.Error {
     case invalidMessageSize
-    case invalidReturnCode
     case invalidLabelSize
     case invalidLabelOffset
     case unicodeDecodingError
@@ -133,7 +132,7 @@ extension Message {
         flags |= (truncation ? 1 : 0) << 9
         flags |= (recursionDesired ? 1 : 0) << 8
         flags |= (recursionAvailable ? 1 : 0) << 7
-        flags |= UInt16(returnCode.rawValue)
+        flags |= UInt16(returnCode)
 
         // header
         bytes += id.bytes
@@ -183,9 +182,7 @@ extension Message {
         id = try UInt16(data: bytes, position: &position)
         let flags = try UInt16(data: bytes, position: &position)
         let operationCode = OperationCode(flags >> 11 & 0x7)
-        guard let returnCode = ReturnCode(rawValue: UInt8(flags & 0x7)) else {
-            throw DecodeError.invalidReturnCode
-        }
+        let returnCode = ReturnCode(flags & 0x7)
 
         type = flags >> 15 & 1 == 1 ? .response : .query
         self.operationCode = operationCode

--- a/Sources/DNS/Bytes.swift
+++ b/Sources/DNS/Bytes.swift
@@ -181,16 +181,14 @@ extension Message {
         var position = bytes.startIndex
         id = try UInt16(data: bytes, position: &position)
         let flags = try UInt16(data: bytes, position: &position)
-        let operationCode = OperationCode(flags >> 11 & 0x7)
-        let returnCode = ReturnCode(flags & 0x7)
-
+        
         type = flags >> 15 & 1 == 1 ? .response : .query
-        self.operationCode = operationCode
+        operationCode = OperationCode(flags >> 11 & 0x7)
         authoritativeAnswer = flags >> 10 & 0x1 == 0x1
         truncation = flags >> 9 & 0x1 == 0x1
         recursionDesired = flags >> 8 & 0x1 == 0x1
         recursionAvailable = flags >> 7 & 0x1 == 0x1
-        self.returnCode = returnCode
+        returnCode = ReturnCode(flags & 0x7)
         
         let numQuestions = try UInt16(data: bytes, position: &position)
         let numAnswers = try UInt16(data: bytes, position: &position)

--- a/Sources/DNS/Bytes.swift
+++ b/Sources/DNS/Bytes.swift
@@ -6,7 +6,6 @@ enum EncodeError: Swift.Error {
 
 enum DecodeError: Swift.Error {
     case invalidMessageSize
-    case invalidOperationCode
     case invalidReturnCode
     case invalidLabelSize
     case invalidLabelOffset
@@ -129,7 +128,7 @@ extension Message {
         var labels = Labels()
         let qr: UInt16 = type == .response ? 1 : 0
         var flags: UInt16 = qr << 15
-        flags |= UInt16(operationCode.rawValue) << 11
+        flags |= UInt16(operationCode) << 11
         flags |= (authoritativeAnswer ? 1 : 0) << 10
         flags |= (truncation ? 1 : 0) << 9
         flags |= (recursionDesired ? 1 : 0) << 8
@@ -183,9 +182,7 @@ extension Message {
         var position = bytes.startIndex
         id = try UInt16(data: bytes, position: &position)
         let flags = try UInt16(data: bytes, position: &position)
-        guard let operationCode = OperationCode(rawValue: UInt8(flags >> 11 & 0x7)) else {
-            throw DecodeError.invalidOperationCode
-        }
+        let operationCode = OperationCode(flags >> 11 & 0x7)
         guard let returnCode = ReturnCode(rawValue: UInt8(flags & 0x7)) else {
             throw DecodeError.invalidReturnCode
         }

--- a/Sources/DNS/IP.swift
+++ b/Sources/DNS/IP.swift
@@ -130,18 +130,18 @@ public struct IPv6: IP {
     }
 
     public var bytes: Data {
-        #if os(OSX)
-            return
-                htonl(address.__u6_addr.__u6_addr32.0).bytes +
-                htonl(address.__u6_addr.__u6_addr32.1).bytes +
-                htonl(address.__u6_addr.__u6_addr32.2).bytes +
-                htonl(address.__u6_addr.__u6_addr32.3).bytes
-        #else
+        #if os(Linux)
             return
                 htonl(address.__in6_u.__u6_addr32.0).bytes +
                 htonl(address.__in6_u.__u6_addr32.1).bytes +
                 htonl(address.__in6_u.__u6_addr32.2).bytes +
                 htonl(address.__in6_u.__u6_addr32.3).bytes
+        #else
+            return
+                htonl(address.__u6_addr.__u6_addr32.0).bytes +
+                htonl(address.__u6_addr.__u6_addr32.1).bytes +
+                htonl(address.__u6_addr.__u6_addr32.2).bytes +
+                htonl(address.__u6_addr.__u6_addr32.3).bytes
         #endif
     }
 }

--- a/Sources/DNS/Types.swift
+++ b/Sources/DNS/Types.swift
@@ -59,13 +59,14 @@ extension Message: CustomDebugStringConvertible {
     }
 }
 
+public typealias OperationCode = UInt8
 
-public enum OperationCode: UInt8 { // 4 bits: 0-15
-    case query = 0 // QUERY
-    case inverseQuery = 1 // IQUERY
-    case statusRequest = 2 // STATUS
-    case notify = 4 // NOTIFY
-    case update = 5 // UPDATE
+public extension OperationCode { // 4 bits: 0-15
+    public static let query: OperationCode = 0 // QUERY
+    public static let inverseQuery: OperationCode = 1 // IQUERY
+    public static let statusRequest: OperationCode = 2 // STATUS
+    public static let notify: OperationCode = 4 // NOTIFY
+    public static let update: OperationCode = 5 // UPDATE
 }
 
 public enum ReturnCode: UInt8 { // 4 bits: 0-15

--- a/Sources/DNS/Types.swift
+++ b/Sources/DNS/Types.swift
@@ -82,12 +82,14 @@ public enum ReturnCode: UInt8 { // 4 bits: 0-15
     case nameNotContainedInZone = 10 // NOTZONE
 }
 
-public enum InternetClass: UInt16 { // 2 bytes
-    case internet = 1 // IN
-    case chaos = 3 // CH
-    case hesiod = 4 // HS
-    case none = 254
-    case any = 255
+public typealias InternetClass = UInt16
+
+public extension InternetClass {
+    public static let internet: InternetClass = 1 // IN
+    public static let chaos: InternetClass = 3 // CH
+    public static let hesiod: InternetClass = 4 // HS
+    public static let none: InternetClass = 254
+    public static let any: InternetClass = 255
 }
 
 public struct Question {
@@ -110,9 +112,8 @@ public struct Question {
         }
         type = recordType
         unique = data[position] & 0x80 == 0x80
-        guard let internetClass = try InternetClass(rawValue: UInt16(data: data, position: &position) & 0x7fff) else {
-            throw DecodeError.invalidInternetClass
-        }
+        let rawInternetClass = try UInt16(data: data, position: &position)
+        let internetClass = InternetClass(rawInternetClass & 0x7fff)
         self.internetClass = internetClass
     }
 }

--- a/Sources/DNS/Types.swift
+++ b/Sources/DNS/Types.swift
@@ -69,18 +69,20 @@ public extension OperationCode { // 4 bits: 0-15
     public static let update: OperationCode = 5 // UPDATE
 }
 
-public enum ReturnCode: UInt8 { // 4 bits: 0-15
-    case noError = 0 // NOERROR
-    case formatError = 1 // FORMERR
-    case serverFailure = 2 // SERVFAIL
-    case nonExistentDomain = 3 // NXDOMAIN
-    case notImplemented = 4 // NOTIMPL
-    case queryRefused = 5 // REFUSED
-    case nameExistsWhenItShouldNot = 6 // YXDOMAIN
-    case rrSetExistsWhenItShouldNot = 7 // YXRRSET
-    case rrSetThatShouldExistDoestNot = 8 // NXRRSET
-    case serverNotAuthoritativeForZone = 9 // NOTAUTH
-    case nameNotContainedInZone = 10 // NOTZONE
+public typealias ReturnCode = UInt8
+
+public extension ReturnCode { // 4 bits: 0-15
+    public static let noError: ReturnCode = 0 // NOERROR
+    public static let formatError: ReturnCode = 1 // FORMERR
+    public static let serverFailure: ReturnCode = 2 // SERVFAIL
+    public static let nonExistentDomain: ReturnCode = 3 // NXDOMAIN
+    public static let notImplemented: ReturnCode = 4 // NOTIMPL
+    public static let queryRefused: ReturnCode = 5 // REFUSED
+    public static let nameExistsWhenItShouldNot: ReturnCode = 6 // YXDOMAIN
+    public static let rrSetExistsWhenItShouldNot: ReturnCode = 7 // YXRRSET
+    public static let rrSetThatShouldExistDoestNot: ReturnCode = 8 // NXRRSET
+    public static let serverNotAuthoritativeForZone: ReturnCode = 9 // NOTAUTH
+    public static let nameNotContainedInZone: ReturnCode = 10 // NOTZONE
 }
 
 public typealias InternetClass = UInt16

--- a/Sources/DNS/Types.swift
+++ b/Sources/DNS/Types.swift
@@ -110,9 +110,7 @@ public struct Question {
 
     init(unpack data: Data, position: inout Data.Index) throws {
         name = try unpackName(data, &position)
-        guard let recordType = ResourceRecordType(rawValue: try UInt16(data: data, position: &position)) else {
-            throw DecodeError.invalidResourceRecordType
-        }
+        let recordType = try ResourceRecordType(data: data, position: &position)
         type = recordType
         unique = data[position] & 0x80 == 0x80
         let rawInternetClass = try UInt16(data: data, position: &position)
@@ -121,20 +119,21 @@ public struct Question {
     }
 }
 
+public typealias ResourceRecordType = UInt16
 
-public enum ResourceRecordType: UInt16 {
-    case host = 0x0001
-    case nameServer = 0x0002
-    case alias = 0x0005
-    case startOfAuthority = 0x0006
-    case pointer = 0x000c
-    case mailExchange = 0x000f
-    case text = 0x0010
-    case host6 = 0x001c
-    case service = 0x0021
-    case incrementalZoneTransfer = 0x00fb
-    case standardZoneTransfer = 0x00fc
-    case all = 0x00ff // All cached records
+public extension ResourceRecordType {
+    public static let host: ResourceRecordType = 0x0001
+    public static let nameServer: ResourceRecordType = 0x0002
+    public static let alias: ResourceRecordType = 0x0005
+    public static let startOfAuthority: ResourceRecordType = 0x0006
+    public static let pointer: ResourceRecordType = 0x000c
+    public static let mailExchange: ResourceRecordType = 0x000f
+    public static let text: ResourceRecordType = 0x0010
+    public static let host6: ResourceRecordType = 0x001c
+    public static let service: ResourceRecordType = 0x0021
+    public static let incrementalZoneTransfer: ResourceRecordType = 0x00fb
+    public static let standardZoneTransfer: ResourceRecordType = 0x00fc
+    public static let all: ResourceRecordType = 0x00ff // All cached records
 }
 
 extension ResourceRecordType: CustomDebugStringConvertible {
@@ -152,6 +151,7 @@ extension ResourceRecordType: CustomDebugStringConvertible {
         case .incrementalZoneTransfer: return "IXFR"
         case .standardZoneTransfer: return "AXFR"
         case .all: return "*"
+        default: return "Unknown"
         }
     }
 }

--- a/Sources/DNS/Types.swift
+++ b/Sources/DNS/Types.swift
@@ -110,12 +110,10 @@ public struct Question {
 
     init(unpack data: Data, position: inout Data.Index) throws {
         name = try unpackName(data, &position)
-        let recordType = try ResourceRecordType(data: data, position: &position)
-        type = recordType
+        type = try ResourceRecordType(data: data, position: &position)
         unique = data[position] & 0x80 == 0x80
         let rawInternetClass = try UInt16(data: data, position: &position)
-        let internetClass = InternetClass(rawInternetClass & 0x7fff)
-        self.internetClass = internetClass
+        internetClass = InternetClass(rawInternetClass & 0x7fff)
     }
 }
 


### PR DESCRIPTION
Not sure if you are interested in this, as it changes the semantics a bit, but ill send it your way anyway.

The point is to allow all values of all the flags, not just those known by the library. I want to use this for a DNS Proxy, and I dont want to unnecessarily prevent packets being handled because of unknown data. (https://tools.ietf.org/html/rfc5625)

Its not complete, as ideally in case of un parseable resource records they would be left as they were.