### PR TITLE
Dont crash trying to encode records with empty names

### DIFF
--- a/Sources/DNS/Bytes.swift
+++ b/Sources/DNS/Bytes.swift
@@ -76,7 +76,11 @@ func serializeName(_ name: String, onto buffer: inout Data, labels: inout Labels
     // position of the new label
     labels[name] = buffer.endIndex
     var components = name.components(separatedBy: ".").filter { $0 != "" }
-
+    guard !components.isEmpty else {
+        buffer.append(0)
+        return
+    }
+    
     let codes = Array(components.removeFirst().utf8)
     buffer.append(UInt8(codes.count))
     buffer += codes


### PR DESCRIPTION
Dig add some additional resource records, I think its the EDNS section, that have empty names