### PR TITLE
Adding a public initializer to AliasRecord

### DIFF
--- a/Sources/DNS/Types.swift
+++ b/Sources/DNS/Types.swift
@@ -237,7 +237,7 @@ public struct AliasRecord {
     public var internetClass: InternetClass
     public var ttl: UInt32
     public var canonicalName: String
-    
+
     public init(name: String, unique: Bool, internetClass: InternetClass, ttl: UInt32, canonicalName: String) {
         self.name = name
         self.unique = unique

--- a/Sources/DNS/Types.swift
+++ b/Sources/DNS/Types.swift
@@ -237,6 +237,14 @@ public struct AliasRecord {
     public var internetClass: InternetClass
     public var ttl: UInt32
     public var canonicalName: String
+    
+    public init(name: String, unique: Bool, internetClass: InternetClass, ttl: UInt32, canonicalName: String) {
+        self.name = name
+        self.unique = unique
+        self.internetClass = internetClass
+        self.ttl = ttl
+        self.canonicalName = canonicalName
+    }
 }
 
 // https://tools.ietf.org/html/rfc1035#section-3.3.13


### PR DESCRIPTION
Added a public initializer to `AliasRecord` so that it can be used from outside the framework. Without this we can't create `AliasRecord` instances because the initializer is assumed to be an internal one.